### PR TITLE
feature: duo_activate.py read text from qr.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,20 @@ Install stuff,
 ```
 pip install -r requirements.txt
 ```
-Grab the text from the QR code, it is the format: XXXXXXXXXX-YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
 
-Use https://www.base64decode.org/ to decode YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY and put it in 'host'
-
-Decoded format should be in the format: api-XXXXX.duosecurity.com . Place that in "Host"
+Copy the QR code image (or create a screenshot) and store it as qr.png into this folder.
 
 Then run:
 ```
 ./duo_activate.py
 ```
+
+In case the QR code cannot be decoded automatically, you will be asked for its text value, it is the format:  
+XXXXXXXXXX-YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+
+The displayed code is the XXXXXXXXXX part of the QR code.  
+The displayed host is the base64 decoded YYYYYY[...] part of the QR code.
+It should be in the format: api-XXXXX.duosecurity.com.
 
 If everything worked you can then generate a code by running:
 

--- a/duo_activate.py
+++ b/duo_activate.py
@@ -1,17 +1,52 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
 import pyotp
 import requests
 import base64
 import json
 import sys
+import cv2
+
+def readQR(filepath):
+  img = cv2.imread(qrFile.name)
+  detector = cv2.QRCodeDetector()
+  data, bbox, straight_qrcode = detector.detectAndDecode(img)
+  if bbox is not None and data != "":
+    print(f"QRCode data:\n{data}")
+  # if no QR code was detected by cv2 let the user input the QR value
+  else: 
+    print("No QR code detected in file.")
+    data = input("Please enter QR Code value manually: ")
+  return data
+
+
+qrFile = Path("qr.png")
+
+# if file exists read QR code. Else let the user input the QR value
+if qrFile.is_file():
+  data = readQR(qrFile.as_posix())
+else:
+  print(qrFile.as_posix()+" not found.")
+  data = input("Please enter QR Code value manually: ")
+
 
 #The QR Code is in the format: XXXXXXXXXX-YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
-#copy 'XXXXXXXXXX' to "code"
-#use https://www.base64decode.org/ to decode YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY and put it in 'host'
-#decoded format should be in the format: api-XXXXX.duosecurity.com
-host = 'api-XXXXX.duosecurity.com'
-code = 'XXXXXXXXXX'
+#storing 'XXXXXXXXXX' part in "code"
+code = data.split("-")[0]
+
+#decode YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY - decoded format should look like: api-XXXXX.duosecurity.com
+b64host = data.split("-")[1]
+# add missing base64 padding for successful base64 decode: https://stackoverflow.com/questions/2941995/python-ignore-incorrect-padding-error-when-base64-decoding
+b64hostpadding = b64host + '=' * (-len(b64host) % 4)
+# decode base64 and convert to string
+host = base64.b64decode(b64hostpadding).decode('utf-8')
+
+print("Code: "+code)
+print("Host: "+host)
+
+#host = 'api-XXXXX.duosecurity.com'
+#code = 'XXXXXXXXXX'
 
 url = 'https://{host}/push/v2/activation/{code}?customer_protocol=1'.format(host=host, code=code)
 headers = {'User-Agent': 'okhttp/2.7.5'}
@@ -22,13 +57,13 @@ data = {'jailbroken': 'false',
         'full_disk_encryption': 'true',
         'passcode_status': 'true',
         'platform': 'Android',
-        'app_version': '3.49.0',
-        'app_build_number': '323001',
-        'version': '11',
+        'app_version': '4.13.0',
+        'app_build_number': '413000',
+        'version': '12',
         'manufacturer': 'unknown',
         'language': 'en',
-        'model': 'Pixel 3a',
-        'security_patch_level': '2021-02-01'}
+        'model': 'unknown',
+        'security_patch_level': '2022-04-01'}
 
 r = requests.post(url, headers=headers, data=data)
 response = json.loads(r.text)

--- a/duo_activate.py
+++ b/duo_activate.py
@@ -47,7 +47,7 @@ hotp = pyotp.HOTP(secret)
 for _ in range(10):
     print(hotp.at(_))
 
-with open('duotoken.hotp', 'w') as file
+with open('duotoken.hotp', 'w') as f:
     f.write(secret.decode() + "\n")
     f.write("0")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyotp
 requests
 pyqrcode
+opencv-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyotp
 requests
+pyqrcode


### PR DESCRIPTION
Hi,

This PR simplifies the duo_activate.py for the user by automatically reading the QR code in the image qr.png.
The QR code png can either be directly copied from the browser ("Save Image As...") or by creating a screenshot.

If the QR code is not recognized by cv2 or the file does not exist, the user will be asked for the QR code text value.

This PR also includes:
* Write to duotoken.hotp fix: https://github.com/revalo/duo-bypass/pull/4
* Added pyqrcode to requirements.txt

Thank you very much for your work!